### PR TITLE
Rework events

### DIFF
--- a/Packages/UGF.Events/Runtime/Event.cs
+++ b/Packages/UGF.Events/Runtime/Event.cs
@@ -2,34 +2,29 @@
 
 namespace UGF.Events.Runtime
 {
-    public abstract class Event<TArguments> : EventBase, IEvent<TArguments>
+    public abstract class Event : EventDynamic, IEvent
     {
-        public void Add(EventHandler<TArguments> handler)
+        public void Add(EventHandler handler)
         {
             if (handler == null) throw new ArgumentNullException(nameof(handler));
 
             OnAdd(handler);
         }
 
-        public bool Remove(EventHandler<TArguments> handler)
+        public bool Remove(EventHandler handler)
         {
             if (handler == null) throw new ArgumentNullException(nameof(handler));
 
             return OnRemove(handler);
         }
 
-        public void Invoke(TArguments arguments)
+        public void Invoke()
         {
-            OnInvoke(arguments);
+            OnInvoke();
         }
 
-        protected override void OnInvoke(object arguments)
-        {
-            Invoke((TArguments)arguments);
-        }
-
-        protected abstract void OnAdd(EventHandler<TArguments> handler);
-        protected abstract bool OnRemove(EventHandler<TArguments> handler);
-        protected abstract void OnInvoke(TArguments arguments);
+        protected abstract void OnAdd(EventHandler handler);
+        protected abstract bool OnRemove(EventHandler handler);
+        protected abstract void OnInvoke();
     }
 }

--- a/Packages/UGF.Events/Runtime/Event.cs.meta
+++ b/Packages/UGF.Events/Runtime/Event.cs.meta
@@ -1,3 +1,3 @@
 ﻿fileFormatVersion: 2
-guid: 35342547a85a4125aeb4e9fc30635d50
-timeCreated: 1615991672
+guid: eb498039385d494f85d972c81033a7ba
+timeCreated: 1633520083

--- a/Packages/UGF.Events/Runtime/EventArguments.cs
+++ b/Packages/UGF.Events/Runtime/EventArguments.cs
@@ -1,6 +1,6 @@
 ﻿namespace UGF.Events.Runtime
 {
-    public class EventArguments : IEventArguments
+    public class EventArguments
     {
         public static EventArguments Empty { get; } = new EventArguments();
     }

--- a/Packages/UGF.Events/Runtime/EventArguments.cs
+++ b/Packages/UGF.Events/Runtime/EventArguments.cs
@@ -1,0 +1,7 @@
+﻿namespace UGF.Events.Runtime
+{
+    public class EventArguments : IEventArguments
+    {
+        public static EventArguments Empty { get; } = new EventArguments();
+    }
+}

--- a/Packages/UGF.Events/Runtime/EventArguments.cs.meta
+++ b/Packages/UGF.Events/Runtime/EventArguments.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 97b0777194ea4865825f873647a53a88
+timeCreated: 1633520945

--- a/Packages/UGF.Events/Runtime/EventCollection`1.cs
+++ b/Packages/UGF.Events/Runtime/EventCollection`1.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace UGF.Events.Runtime
 {
-    public abstract class EventCollection<TCollection> : Event where TCollection : ICollection<EventHandler>
+    public abstract class EventCollection<TCollection, TArguments> : Event<TArguments> where TCollection : ICollection<EventHandler<TArguments>>
     {
         protected TCollection Collection { get; }
 
@@ -14,20 +14,20 @@ namespace UGF.Events.Runtime
 
         protected override void OnAdd(Delegate handler)
         {
-            OnAdd((EventHandler)handler);
+            OnAdd((EventHandler<TArguments>)handler);
         }
 
         protected override bool OnRemove(Delegate handler)
         {
-            return OnRemove((EventHandler)handler);
+            return OnRemove((EventHandler<TArguments>)handler);
         }
 
-        protected override void OnAdd(EventHandler handler)
+        protected override void OnAdd(EventHandler<TArguments> handler)
         {
             Collection.Add(handler);
         }
 
-        protected override bool OnRemove(EventHandler handler)
+        protected override bool OnRemove(EventHandler<TArguments> handler)
         {
             return Collection.Remove(handler);
         }
@@ -39,7 +39,7 @@ namespace UGF.Events.Runtime
 
         protected override void OnInvoke(object arguments)
         {
-            OnInvoke();
+            OnInvoke((TArguments)arguments);
         }
     }
 }

--- a/Packages/UGF.Events/Runtime/EventCollection`1.cs.meta
+++ b/Packages/UGF.Events/Runtime/EventCollection`1.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 46aecccca55c4df4b5b1377ab4182512
+timeCreated: 1633520767

--- a/Packages/UGF.Events/Runtime/EventDynamic.cs
+++ b/Packages/UGF.Events/Runtime/EventDynamic.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace UGF.Events.Runtime
+{
+    public abstract class EventDynamic : IEventDynamic
+    {
+        public void Add(Delegate handler)
+        {
+            if (handler == null) throw new ArgumentNullException(nameof(handler));
+
+            OnAdd(handler);
+        }
+
+        public bool Remove(Delegate handler)
+        {
+            return OnRemove(handler);
+        }
+
+        public void Clear()
+        {
+            OnClear();
+        }
+
+        public void Invoke(object arguments)
+        {
+            if (arguments == null) throw new ArgumentNullException(nameof(arguments));
+
+            OnInvoke(arguments);
+        }
+
+        protected abstract void OnAdd(Delegate handler);
+        protected abstract bool OnRemove(Delegate handler);
+        protected abstract void OnClear();
+        protected abstract void OnInvoke(object arguments);
+    }
+}

--- a/Packages/UGF.Events/Runtime/EventDynamic.cs.meta
+++ b/Packages/UGF.Events/Runtime/EventDynamic.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3ff34ccc69204fdb81e995d39605e304
+timeCreated: 1633520364

--- a/Packages/UGF.Events/Runtime/EventExtensions.cs
+++ b/Packages/UGF.Events/Runtime/EventExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace UGF.Events.Runtime
+{
+    public static class EventExtensions
+    {
+        public static void InvokeEmpty(this EventDynamic eventDynamic)
+        {
+            if (eventDynamic == null) throw new ArgumentNullException(nameof(eventDynamic));
+
+            eventDynamic.Invoke(EventArguments.Empty);
+        }
+    }
+}

--- a/Packages/UGF.Events/Runtime/EventExtensions.cs.meta
+++ b/Packages/UGF.Events/Runtime/EventExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f734c183ed56443cba8a22add955cb70
+timeCreated: 1633521699

--- a/Packages/UGF.Events/Runtime/EventHandler.cs
+++ b/Packages/UGF.Events/Runtime/EventHandler.cs
@@ -1,4 +1,4 @@
 ﻿namespace UGF.Events.Runtime
 {
-    public delegate void EventHandler(object arguments);
+    public delegate void EventHandler();
 }

--- a/Packages/UGF.Events/Runtime/EventList.cs
+++ b/Packages/UGF.Events/Runtime/EventList.cs
@@ -1,44 +1,29 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace UGF.Events.Runtime
 {
-    public class EventList<TArguments> : EventCollection<TArguments>
+    public class EventList : EventCollection<List<EventHandler>>
     {
-        private readonly List<Delegate> m_handlers;
-        private readonly List<Delegate> m_invoke = new List<Delegate>();
+        private readonly List<EventHandler> m_invoke = new List<EventHandler>();
 
-        public EventList() : base(new List<Delegate>())
+        public EventList(int capacity = 4) : this(new List<EventHandler>(capacity))
         {
-            m_handlers = (List<Delegate>)Handlers;
         }
 
-        protected override void OnInvoke(TArguments arguments)
+        public EventList(List<EventHandler> collection) : base(collection)
         {
-            foreach (Delegate handler in m_handlers)
+        }
+
+        protected override void OnInvoke()
+        {
+            for (int i = 0; i < Collection.Count; i++)
             {
-                m_invoke.Add(handler);
+                m_invoke.Add(Collection[i]);
             }
 
-            object argumentsBoxed = null;
-
-            foreach (Delegate handler in m_invoke)
+            for (int i = 0; i < m_invoke.Count; i++)
             {
-                switch (handler)
-                {
-                    case EventHandler handlerObject:
-                    {
-                        argumentsBoxed ??= arguments;
-
-                        handlerObject(argumentsBoxed);
-                        break;
-                    }
-                    case EventHandler<TArguments> handlerTyped:
-                    {
-                        handlerTyped(arguments);
-                        break;
-                    }
-                }
+                m_invoke[i].Invoke();
             }
 
             m_invoke.Clear();

--- a/Packages/UGF.Events/Runtime/EventList`1.cs
+++ b/Packages/UGF.Events/Runtime/EventList`1.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+
+namespace UGF.Events.Runtime
+{
+    public class EventList<TArguments> : EventCollection<List<EventHandler<TArguments>>, TArguments>
+    {
+        private readonly List<EventHandler<TArguments>> m_invoke = new List<EventHandler<TArguments>>();
+
+        public EventList(int capacity = 4) : this(new List<EventHandler<TArguments>>(capacity))
+        {
+        }
+
+        public EventList(List<EventHandler<TArguments>> collection) : base(collection)
+        {
+        }
+
+        protected override void OnInvoke(TArguments arguments)
+        {
+            for (int i = 0; i < Collection.Count; i++)
+            {
+                m_invoke.Add(Collection[i]);
+            }
+
+            for (int i = 0; i < m_invoke.Count; i++)
+            {
+                m_invoke[i].Invoke(arguments);
+            }
+
+            m_invoke.Clear();
+        }
+    }
+}

--- a/Packages/UGF.Events/Runtime/EventList`1.cs.meta
+++ b/Packages/UGF.Events/Runtime/EventList`1.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: df399016a4ef4049bd8cf1875e373d08
+timeCreated: 1633521238

--- a/Packages/UGF.Events/Runtime/EventSet.cs
+++ b/Packages/UGF.Events/Runtime/EventSet.cs
@@ -3,42 +3,28 @@ using System.Collections.Generic;
 
 namespace UGF.Events.Runtime
 {
-    public class EventSet<TArguments> : EventCollection<TArguments>
+    public class EventSet : EventCollection<HashSet<EventHandler>>
     {
-        private readonly HashSet<Delegate> m_handlers;
-        private readonly HashSet<Delegate> m_invoke = new HashSet<Delegate>();
+        private readonly HashSet<EventHandler> m_invoke = new HashSet<EventHandler>();
 
-        public EventSet() : base(new HashSet<Delegate>())
+        public EventSet() : this(new HashSet<EventHandler>())
         {
-            m_handlers = (HashSet<Delegate>)Handlers;
         }
 
-        protected override void OnInvoke(TArguments arguments)
+        public EventSet(HashSet<EventHandler> collection) : base(collection)
         {
-            foreach (Delegate handler in m_handlers)
+        }
+
+        protected override void OnInvoke()
+        {
+            foreach (EventHandler handler in Collection)
             {
                 m_invoke.Add(handler);
             }
 
-            object argumentsBoxed = null;
-
-            foreach (Delegate handler in m_invoke)
+            foreach (EventHandler handler in m_invoke)
             {
-                switch (handler)
-                {
-                    case EventHandler handlerObject:
-                    {
-                        argumentsBoxed ??= arguments;
-
-                        handlerObject(argumentsBoxed);
-                        break;
-                    }
-                    case EventHandler<TArguments> handlerTyped:
-                    {
-                        handlerTyped(arguments);
-                        break;
-                    }
-                }
+                handler.Invoke();
             }
 
             m_invoke.Clear();

--- a/Packages/UGF.Events/Runtime/EventSet`1.cs
+++ b/Packages/UGF.Events/Runtime/EventSet`1.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+
+namespace UGF.Events.Runtime
+{
+    public class EventSet<TArguments> : EventCollection<HashSet<EventHandler<TArguments>>, TArguments>
+    {
+        private readonly HashSet<EventHandler<TArguments>> m_invoke = new HashSet<EventHandler<TArguments>>();
+
+        public EventSet() : this(new HashSet<EventHandler<TArguments>>())
+        {
+        }
+
+        public EventSet(HashSet<EventHandler<TArguments>> collection) : base(collection)
+        {
+        }
+
+        protected override void OnInvoke(TArguments arguments)
+        {
+            foreach (EventHandler<TArguments> handler in Collection)
+            {
+                m_invoke.Add(handler);
+            }
+
+            foreach (EventHandler<TArguments> handler in m_invoke)
+            {
+                handler.Invoke(arguments);
+            }
+
+            m_invoke.Clear();
+        }
+    }
+}

--- a/Packages/UGF.Events/Runtime/EventSet`1.cs.meta
+++ b/Packages/UGF.Events/Runtime/EventSet`1.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e5ca4e35589041c7bad7e7c0afca8e99
+timeCreated: 1633521450

--- a/Packages/UGF.Events/Runtime/Event`1.cs
+++ b/Packages/UGF.Events/Runtime/Event`1.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace UGF.Events.Runtime
+{
+    public abstract class Event<TArguments> : EventDynamic, IEvent<TArguments>
+    {
+        public void Add(EventHandler<TArguments> handler)
+        {
+            if (handler == null) throw new ArgumentNullException(nameof(handler));
+
+            OnAdd(handler);
+        }
+
+        public bool Remove(EventHandler<TArguments> handler)
+        {
+            if (handler == null) throw new ArgumentNullException(nameof(handler));
+
+            return OnRemove(handler);
+        }
+
+        public void Invoke(TArguments arguments)
+        {
+            OnInvoke(arguments);
+        }
+
+        protected abstract void OnAdd(EventHandler<TArguments> handler);
+        protected abstract bool OnRemove(EventHandler<TArguments> handler);
+        protected abstract void OnInvoke(TArguments arguments);
+    }
+}

--- a/Packages/UGF.Events/Runtime/Event`1.cs.meta
+++ b/Packages/UGF.Events/Runtime/Event`1.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 35342547a85a4125aeb4e9fc30635d50
+timeCreated: 1615991672

--- a/Packages/UGF.Events/Runtime/IEvent.cs
+++ b/Packages/UGF.Events/Runtime/IEvent.cs
@@ -2,11 +2,7 @@
 {
     public interface IEvent
     {
-        int Count { get; }
-
         void Add(EventHandler handler);
         bool Remove(EventHandler handler);
-        void Invoke(object arguments);
-        void Clear();
     }
 }

--- a/Packages/UGF.Events/Runtime/IEventArguments.cs
+++ b/Packages/UGF.Events/Runtime/IEventArguments.cs
@@ -1,6 +1,0 @@
-﻿namespace UGF.Events.Runtime
-{
-    public interface IEventArguments
-    {
-    }
-}

--- a/Packages/UGF.Events/Runtime/IEventArguments.cs
+++ b/Packages/UGF.Events/Runtime/IEventArguments.cs
@@ -1,0 +1,6 @@
+﻿namespace UGF.Events.Runtime
+{
+    public interface IEventArguments
+    {
+    }
+}

--- a/Packages/UGF.Events/Runtime/IEventArguments.cs.meta
+++ b/Packages/UGF.Events/Runtime/IEventArguments.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7c498caeb7764915bcdbbff9e77f5edc
+timeCreated: 1633520932

--- a/Packages/UGF.Events/Runtime/IEventArguments.cs.meta
+++ b/Packages/UGF.Events/Runtime/IEventArguments.cs.meta
@@ -1,3 +1,0 @@
-﻿fileFormatVersion: 2
-guid: 7c498caeb7764915bcdbbff9e77f5edc
-timeCreated: 1633520932

--- a/Packages/UGF.Events/Runtime/IEventDynamic.cs
+++ b/Packages/UGF.Events/Runtime/IEventDynamic.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace UGF.Events.Runtime
+{
+    public interface IEventDynamic
+    {
+        void Add(Delegate handler);
+        bool Remove(Delegate handler);
+    }
+}

--- a/Packages/UGF.Events/Runtime/IEventDynamic.cs.meta
+++ b/Packages/UGF.Events/Runtime/IEventDynamic.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0d8c4fbd1d734bf5a4d5cb46fa332d85
+timeCreated: 1633520323

--- a/Packages/UGF.Events/Runtime/IEvent`1.cs
+++ b/Packages/UGF.Events/Runtime/IEvent`1.cs
@@ -1,9 +1,8 @@
 ﻿namespace UGF.Events.Runtime
 {
-    public interface IEvent<TArguments> : IEvent
+    public interface IEvent<out TArguments>
     {
         void Add(EventHandler<TArguments> handler);
         bool Remove(EventHandler<TArguments> handler);
-        void Invoke(TArguments arguments);
     }
 }

--- a/Packages/UGF.Events/package.json
+++ b/Packages/UGF.Events/package.json
@@ -2,7 +2,7 @@
   "name": "com.ugf.events",
   "displayName": "UGF.Events",
   "version": "0.1.0-preview",
-  "unity": "2020.2",
+  "unity": "2021.1",
   "apiCompatibility": ".NET Standard 2.0",
   "description": "Events system implementation.",
   "author": {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "3.0.5",
-    "com.unity.test-framework": "1.1.24"
+    "com.unity.ide.rider": "3.0.7",
+    "com.unity.test-framework": "1.1.29"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -14,14 +14,16 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.5",
+      "version": "3.0.7",
       "depth": 0,
       "source": "registry",
-      "dependencies": {},
+      "dependencies": {
+        "com.unity.ext.nunit": "1.0.6"
+      },
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.24",
+      "version": "1.1.29",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.0f1
-m_EditorVersionWithRevision: 2020.3.0f1 (c7b5465681fb)
+m_EditorVersion: 2021.1.19f1
+m_EditorVersionWithRevision: 2021.1.19f1 (5f5eb8bbdc25)


### PR DESCRIPTION
- Add `EventDynamic` class to call events dynamically without knowing event type.
- Change `IEvent` and `IEvent<T>` interfaces to be separated and used with or without arguments.
- Change `EventCollection` and related classes to support changed event interfaces.
- Change `EventList` and `EventSet` classes to support changed event interfaces.